### PR TITLE
Next-fit

### DIFF
--- a/mm.c
+++ b/mm.c
@@ -278,6 +278,7 @@ void *coalesce(byte_p bp) {
     PUT(HEADER_PTR(bp), packed);
     PUT(FOOTER_PTR(next_bp), packed);
 
+    g_cur = bp;
     return bp;
   }
 

--- a/mm.c
+++ b/mm.c
@@ -33,8 +33,11 @@ static void place(void *bp, size_t asize);
 inline static size_t adjust_size(size_t size);
 inline static bool is_prologue(void *bp);
 inline static bool is_epilogue(void *bp);
+void *first_fit(size_t asize);
+void *next_fit(size_t asize);
 
 void *g_heap_listp;
+void *g_cur;
 
 /*********************************************************
  * NOTE TO STUDENTS: Before you do anything else, please
@@ -122,6 +125,8 @@ int mm_init(void) {
   PUT(g_heap_listp + (2 * WSIZE), PACK(DSIZE, 1));  // prologue footer
   PUT(g_heap_listp + (3 * WSIZE), PACK(0, 1));      // epilogue header
   g_heap_listp += (2 * WSIZE);
+
+  g_cur = g_heap_listp;
 
   // Extend the empty heap with a free block of CHUNKSIZE bytes
   if (extend_heap(CHUNKSIZE / WSIZE) == NULL) {
@@ -260,6 +265,7 @@ void *coalesce(byte_p bp) {
     PUT(HEADER_PTR(prev_bp), packed);
     PUT(FOOTER_PTR(bp), packed);
 
+    g_cur = prev_bp;
     return prev_bp;
   }
 
@@ -284,6 +290,7 @@ void *coalesce(byte_p bp) {
   PUT(HEADER_PTR(prev_bp), packed);
   PUT(FOOTER_PTR(next_bp), packed);
 
+  g_cur = prev_bp;
   return prev_bp;
 }
 
@@ -292,7 +299,9 @@ void *coalesce(byte_p bp) {
  *
  * @return asize <= BLOCK_SIZE - 2WSIZE를 만족하는 블럭 포인터 | NULL
  */
-void *find_fit(size_t asize) {
+void *find_fit(size_t asize) { return next_fit(asize); }
+
+void *first_fit(size_t asize) {
   for (void *cur = g_heap_listp; GET_SIZE(HEADER_PTR(cur)) > 0;
        cur = NEXT_BLOCK_PTR(cur)) {
     if (!GET_ALLOC(HEADER_PTR(cur)) && (asize <= GET_SIZE(HEADER_PTR(cur)))) {
@@ -300,6 +309,28 @@ void *find_fit(size_t asize) {
     }
   }
 
+  return NULL;
+}
+
+void *next_fit(size_t asize) {
+  // g_cur -> epilogue
+  for (void *cur = g_cur; GET_SIZE(HEADER_PTR(cur)) > 0;
+       cur = NEXT_BLOCK_PTR(cur)) {
+    void *p = HEADER_PTR(cur);
+    if (!GET_ALLOC(p) && asize <= GET_SIZE(p)) {
+      g_cur = cur;
+      return cur;
+    }
+  }
+
+  // prologue -> g_cur
+  for (void *cur = g_heap_listp; cur < g_cur; cur = NEXT_BLOCK_PTR(cur)) {
+    void *p = HEADER_PTR(cur);
+    if (!GET_ALLOC(p) && asize <= GET_SIZE(p)) {
+      g_cur = cur;
+      return cur;
+    }
+  }
   return NULL;
 }
 
@@ -332,6 +363,8 @@ void place(void *bp, size_t asize) {
     PUT(HEADER_PTR(bp), pack_all);
     PUT(FOOTER_PTR(bp), pack_all);
   }
+
+  g_cur = bp;
 }
 
 /**


### PR DESCRIPTION
cur의 위치를 전역변수 `g_cur`로 보존한 뒤에 `find_fit` 호출 시 처음부터 탐색하는 것이 아니라 `g_cur`의 위치부터 탐색을 시작합니다.

## `coalesce`

prev일 때에만 `g_cur`를 수정했는데, 그러지 말고 모든 경우의 수에 해당하는 free block의 위치를 `g_cur`에 할당을 해 주어야 합니다. 예를 들어 next만 가용이고 prev가 채워져 있는 경우일지라도 일단 `g_cur = bp`를 해 주어야만 overlap이 일어나지 않더라구요.

## `next_fit`

`void *` 비교연산은 굳이 `char *`로 바꾸지 않아도 가능하다는 사실.

`g_cur` 에서 출발해 `epliogue`로 도착하는 반복문 하나, `prologue`에서 출발해 `g_cur`로 도착하는 반복문 하나, 이때 언제나 allocate 여부를 조사하기 때문에 `g_cur`를 항상 가용 블럭으로 줄 필요가 없습니다.

## `place`

모든 `mm_malloc` 작업의 마지막을 장식하는 place에서 g_cur의 값을 바꿔주었습니다.

